### PR TITLE
correct the name of constant for the kubernetes deployments

### DIFF
--- a/consul-operator/pkg/controller/consul/handlers.go
+++ b/consul-operator/pkg/controller/consul/handlers.go
@@ -29,9 +29,9 @@ import (
 )
 
 const (
-	deploymentTypeDeploymentset = "deploymentsets"
-	deploymentTypeStatefulset   = "statefulsets"
-	deploymentTypeDaemonset     = "deamonsets"
+	deploymentTypeDeployment  = "deployments"
+	deploymentTypeStatefulset = "statefulsets"
+	deploymentTypeDaemonset   = "deamonsets"
 )
 
 type deploymentType string


### PR DESCRIPTION
Fix the IP address reporting in the app-reported-data in case of Kubernetes deployment type