### PR TITLE
Update monitoring.go to start the watch from the creation of the pods and not from the actual latest state

### DIFF
--- a/consul-operator/pkg/monitoring/monitoring.go
+++ b/consul-operator/pkg/monitoring/monitoring.go
@@ -165,6 +165,7 @@ func (m *Monitor) GetApplicationStatus() app.AppStatus {
 func (m *Monitor) watchInformer(eventHandler cache.ResourceEventHandler, stopper chan struct{}) {
 	listOptionsFunc := internalinterfaces.TweakListOptionsFunc(func(options *v1.ListOptions) {
 		options.LabelSelector = "statusCheck=true"
+		options.ResourceVersion = "0"
 	})
 
 	informer := informersv1.NewFilteredPodInformer(


### PR DESCRIPTION
- start the watch of the pods from the creation
- this fix solves the issue when the application pods go to running state earlier than the actual pod monitoring would be started